### PR TITLE
Update selectors and Enter handling for new Gemini UI

### DIFF
--- a/app/src/contents/adapters/gemini.ts
+++ b/app/src/contents/adapters/gemini.ts
@@ -1,7 +1,7 @@
 import type { SiteAdapter } from "../site-adapter";
 
 const EDITOR_SEL = "div.ql-editor[contenteditable='true']";
-const SEND_BTN_SEL = "button.send-button";
+const SEND_BTN_SEL = ".send-button-container button, button[aria-label='プロンプトを送信'], button[aria-label='Send prompt']";
 const RESPONSE_BLOCK_SEL =
   ":scope .markdown > p, :scope .markdown > h3, :scope .markdown > ol, :scope .markdown > ul, :scope .markdown > response-element";
 

--- a/app/src/contents/keymap-controller.ts
+++ b/app/src/contents/keymap-controller.ts
@@ -86,18 +86,18 @@ export function initKeymapController(adapter: SiteAdapter) {
       return;
     }
 
-    // Ctrl+Enter -> send
-    if (e.key === "Enter" && e.ctrlKey && !e.shiftKey) {
+    // Ctrl+Enter or Shift+Enter -> send
+    if (e.key === "Enter" && (e.ctrlKey || e.shiftKey) && !e.metaKey) {
       e.preventDefault();
       e.stopPropagation();
       adapter.send();
       return;
     }
 
-    // Enter (plain) -> newline
+    // Enter (plain) -> newline (block default send behavior)
     if (e.key === "Enter" && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
       e.preventDefault();
-      e.stopPropagation();
+      e.stopImmediatePropagation();
       document.execCommand("insertLineBreak");
     }
   }


### PR DESCRIPTION
resolve #11 

- Update send button selector to match new .send-button-container structure
- Use stopImmediatePropagation to block Quill's Enter handler
- Allow Shift+Enter as alternative send trigger