### PR TITLE
fix: support blockquote in response blocks and fix j key navigation

### DIFF
--- a/app/src/contents/adapters/gemini.ts
+++ b/app/src/contents/adapters/gemini.ts
@@ -3,7 +3,7 @@ import type { SiteAdapter } from "../site-adapter";
 const EDITOR_SEL = "div.ql-editor[contenteditable='true']";
 const SEND_BTN_SEL = ".send-button-container button, button[aria-label='プロンプトを送信'], button[aria-label='Send prompt']";
 const RESPONSE_BLOCK_SEL =
-  ":scope .markdown > p, :scope .markdown > h3, :scope .markdown > ol, :scope .markdown > ul, :scope .markdown > response-element";
+  ":scope .markdown > p, :scope .markdown > h3, :scope .markdown > ol, :scope .markdown > ul, :scope .markdown > blockquote, :scope .markdown > response-element";
 
 export const geminiAdapter: SiteAdapter = {
   getEditor() {

--- a/app/src/contents/keymap-controller.ts
+++ b/app/src/contents/keymap-controller.ts
@@ -144,10 +144,10 @@ export function initKeymapController(adapter: SiteAdapter) {
         if (msgs.length === 0) return;
         if (msgIndex < msgs.length - 1) {
           msgIndex++;
-          highlightAndScroll(msgs[msgIndex]);
-        } else {
-          enterInsertMode();
+        } else if (msgIndex === -1) {
+          msgIndex = 0;
         }
+        highlightAndScroll(msgs[msgIndex]);
         return;
       }
 


### PR DESCRIPTION
## Summary

- Add `<blockquote>` to `RESPONSE_BLOCK_SEL` in gemini adapter so blockquote elements are recognized as response blocks.
- Prevent entering insert mode when pressing `j` at the last message.
- Select and highlight the first message when pressing `j` with no message selected.

Closes #17